### PR TITLE
parse effective date from primary affiliation data

### DIFF
--- a/lib/mais_person_client/person.rb
+++ b/lib/mais_person_client/person.rb
@@ -193,7 +193,7 @@ class MaisPersonClient
       aff.department&.adminid
     end
 
-    # returns the org_id for the primary affiliation (affnum == '1')
+    # returns the effective_date for the primary affiliation (affnum == '1')
     def primary_effective_date
       # Find the affiliation with affnum == '1' and return the effective date
       aff = affiliations.find { |a| a.affnum == '1' }

--- a/lib/mais_person_client/person.rb
+++ b/lib/mais_person_client/person.rb
@@ -193,6 +193,16 @@ class MaisPersonClient
       aff.department&.adminid
     end
 
+    # returns the org_id for the primary affiliation (affnum == '1')
+    def primary_effective_date
+      # Find the affiliation with affnum == '1' and return the effective date
+      aff = affiliations.find { |a| a.affnum == '1' }
+      return nil unless aff
+
+      # effective date
+      aff.effective
+    end
+
     # indicates if a person is a member of the academic council
     def academic_council?
       # If there are no affiliations, the person is not a member of the academic council

--- a/spec/mais_person_client/person_spec.rb
+++ b/spec/mais_person_client/person_spec.rb
@@ -352,6 +352,24 @@ RSpec.describe MaisPersonClient::Person do
       end
     end
 
+    describe '#primary_effective_date' do
+      it 'returns the effective date for affiliation with affnum=1' do
+        expect(person.primary_effective_date).to eq('1934-06-09')
+      end
+
+      it 'returns nil when affiliation with affnum=1 is missing' do
+        xml = <<~XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <Person>
+            <affiliation affnum="2" effective="2020-01-01" />
+          </Person>
+        XML
+
+        p = described_class.new(xml)
+        expect(p.primary_effective_date).to be_nil
+      end
+    end
+
     describe '#primary_role' do
       it 'returns the affiliation type for affnum=1' do
         expect(person.primary_role).to eq('staff')


### PR DESCRIPTION
Pull effective date from affnum=1 so we can use this when loading data into rialto-orgs